### PR TITLE
download deislab shims

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1.5-labs
 
-ARG RUST_VERSION=1.69.0
-ARG WASMEDGE_VERSION=0.12.1
 ARG XX_VERSION=1.2.1
+ARG RUST_VERSION=1.69.0
+ARG WASMEDGE_VERSION=0.13.1
+ARG DEISLABS_SHIMS_VERSION=0.7.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION} AS base
@@ -19,7 +20,11 @@ RUN mkdir -p /.cargo && \
     echo 'git-fetch-with-cli = true' >> /.cargo/config
 
 FROM base as containerd-wasm-shims
-ADD https://github.com/deislabs/containerd-wasm-shims.git /containerd-wasm-shims
+ARG BUILD_TAGS TARGETPLATFORM DEISLABS_SHIMS_VERSION
+SHELL ["/bin/bash", "-c"]
+RUN mkdir -p /dist/ && \
+    curl -sSfL https://github.com/deislabs/containerd-wasm-shims/releases/download/v${DEISLABS_SHIMS_VERSION}/containerd-wasm-shims-v1-linux-$(xx-info march).tar.gz \
+        | tar -xzC/dist/
 
 FROM base as runwasi
 ADD https://github.com/containerd/runwasi.git /runwasi
@@ -36,57 +41,30 @@ ARG BUILD_TAGS TARGETPLATFORM WASMEDGE_VERSION
 RUN xx-apt-get install -y gcc g++ libc++6-dev zlib1g libdbus-1-dev libseccomp-dev
 RUN rustup target add wasm32-wasi
 
-RUN <<EOT
-    set -ex
-    os=$(xx-info os)
-    curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- \
+RUN curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- \
         --version ${WASMEDGE_VERSION} \
-        --platform ${os^} \
+        --platform $(xx-info os | sed -e 's/\b\(.\)/\u\1/g') \
         --machine $(xx-info march) \
         --path /usr/local
-EOT
 
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/cache \
     --mount=type=cache,target=/usr/local/cargo/registry/index \
-    --mount=type=cache,target=/build/app,id=wasmedge-wasmtime-$TARGETPLATFORM <<EOT
+    --mount=type=cache,target=/build,id=containerd-wasi-shims-$TARGETPLATFORM <<EOT
     set -e
     export RUSTFLAGS='-Clink-arg=-Wl,-rpath,$ORIGIN'
-    xx-cargo build --release --target-dir /build/app
-    cp /build/app/$(xx-cargo --print-target-triple)/release/containerd-shim-wasm{time,edge}-v1 /
-EOT
-
-FROM containerd-wasm-shims as build-containerd-wasm-shims
-WORKDIR /containerd-wasm-shims
-RUN --mount=type=cache,target=/usr/local/cargo/git/db \
-    --mount=type=cache,target=/usr/local/cargo/registry/cache \
-    --mount=type=cache,target=/usr/local/cargo/registry/index \
-    --mount=type=cache,target=/build/app,id=containerd-shims-$TARGETPLATFORM \
-    cargo fetch
-ARG BUILD_TAGS TARGETPLATFORM
-SHELL ["/bin/bash", "-c"]
-RUN xx-apt-get install -y gcc g++ libc++6-dev zlib1g
-RUN rustup target add wasm32-{wasi,unknown-unknown}
-
-RUN --mount=type=cache,target=/usr/local/cargo/git/db \
-    --mount=type=cache,target=/usr/local/cargo/registry/cache \
-    --mount=type=cache,target=/usr/local/cargo/registry/index \
-    --mount=type=cache,target=/build/app,id=containerd-shims-$TARGETPLATFORM <<EOT
-    set -e
-    xx-cargo build --release --target-dir /build/app --manifest-path=containerd-shim-spin-v1/Cargo.toml
-    xx-cargo build --release --target-dir /build/app --manifest-path=containerd-shim-slight-v1/Cargo.toml
-    cp /build/app/$(xx-cargo --print-target-triple)/release/containerd-shim-{spin,slight}-v1 /
+    xx-cargo build --release --target-dir /build/ --bin=containerd-shim-wasm{time,edge}-v1
+    mkdir -p /dist/
+    cp /build/$(xx-cargo --print-target-triple)/release/containerd-shim-wasm{time,edge}-v1 /dist/
+    cp /usr/local/lib/libwasmedge.so.0.* /dist/libwasmedge.so.0
 EOT
 
 FROM scratch AS release
 
 # Deislabs containerd shims
-COPY --link --from=build-containerd-wasm-shims /containerd-shim-spin-v1 /containerd-shim-spin-v1
-COPY --link --from=build-containerd-wasm-shims /containerd-shim-slight-v1 /containerd-shim-slight-v1
+COPY --link --from=containerd-wasm-shims /dist/* /
 
 # Runwasi shims
-COPY --link --from=build-runwasi /usr/local/lib/libwasmedge.so.0.* /libwasmedge.so.0
-COPY --link --from=build-runwasi /containerd-shim-wasmedge-v1 /containerd-shim-wasmedge-v1
-COPY --link --from=build-runwasi /containerd-shim-wasmtime-v1 /containerd-shim-wasmtime-v1
+COPY --link --from=build-runwasi /dist/* /
 
 FROM release


### PR DESCRIPTION
This change downloads the deislab shims instead of building them.
This should significantly reduces the disk usage in the GH Actions runner.
It also updates the wasmedge version to `0.13.1`.